### PR TITLE
Feat/new_overground_names

### DIFF
--- a/site/tflStatus.js
+++ b/site/tflStatus.js
@@ -23,6 +23,12 @@ const lineColors = {
   'DLR': '#00AFAA',
   'Elizabeth line': '#773DBD',
   'London Overground': '#EE7623',
+  'Liberty': '#61686B',
+  'Lioness': '#FFA600',
+  'Mildmay': '#006FE6',
+  'Suffragette': '#18A95D',
+  'Weaver': '#9B0058',
+  'Windrush': '#DC241F'
 };
 
 // Function to extract max-age from Cache-Control header
@@ -151,7 +157,7 @@ const printUsageInstructions = () => {
   console.log('from https://github.com/mnbf9rca/super_simple_tfl_status')
   console.log('Usage Instructions:');
   console.log('1. mode: The mode of transportation. Default is "tube,elizabeth-line". Recommended list of modes: tube,elizabeth-line,dlr,overground.');
-  console.log('   You can put any value here - it will be passed to TfL API which may return an error (check console).');  
+  console.log('   You can put any value here - it will be passed to TfL API which may return an error (check console).');
   console.log('   Example: ?mode=tube');
   console.log('2. names: Whether to show names of the lines. Default is false.');
   console.log('   Example: ?names=true');

--- a/site/tflStatus.js
+++ b/site/tflStatus.js
@@ -73,6 +73,7 @@ const extractLineStatuses = (data, showNames) => {
       disruptedLines.push({
         message: showNames ? line.name : '',
         bgColor: lineColours[line.name].colour || '#000',
+        solid: lineColours[line.name].solid
       });
     }
   });

--- a/site/tflStatus.js
+++ b/site/tflStatus.js
@@ -7,28 +7,29 @@
 
 // Define line colors
 // https://content.tfl.gov.uk/tfl-colour-standard-issue-08.pdf
+// plus new Overground line names: https://blog.tfl.gov.uk/2024/03/08/london-overground-lines/
 const lineColors = {
-  'Bakerloo': '#A65A2A',
-  'Central': '#E1251B',
-  'Circle': '#FFCD00',
-  'District': '#007934',
-  'Hammersmith & City': '#EC9BAD',
-  'Jubilee': '#7B868C',
-  'Metropolitan': '#870F54',
-  'Northern': '#000000',
-  'Piccadilly': '#000F9F',
-  'Victoria': '#00A0DF',
-  'Waterloo & City': '#6BCDB2',
-  'Transport for London': '#000F9F',
-  'DLR': '#00AFAA',
-  'Elizabeth line': '#773DBD',
-  'London Overground': '#EE7623',
-  'Liberty': '#61686B',
-  'Lioness': '#FFA600',
-  'Mildmay': '#006FE6',
-  'Suffragette': '#18A95D',
-  'Weaver': '#9B0058',
-  'Windrush': '#DC241F'
+  'Bakerloo': { 'colour': '#A65A2A', 'solid': true },
+  'Central': { 'colour': '#E1251B', 'solid': true },
+  'Circle': { 'colour': '#FFCD00', 'solid': true },
+  'District': { 'colour': '#007934', 'solid': true },
+  'Hammersmith & City': { 'colour': '#EC9BAD', 'solid': true },
+  'Jubilee': { 'colour': '#7B868C', 'solid': true },
+  'Metropolitan': { 'colour': '#870F54', 'solid': true },
+  'Northern': { 'colour': '#000000', 'solid': true },
+  'Piccadilly': { 'colour': '#000F9F', 'solid': true },
+  'Victoria': { 'colour': '#00A0DF', 'solid': true },
+  'Waterloo & City': { 'colour': '#6BCDB2', 'solid': true },
+  'Transport for London': { 'colour': '#000F9F', 'solid': true },
+  'DLR': { 'colour': '#00AFAA', 'solid': true },
+  'Elizabeth line': { 'colour': '#773DBD', 'solid': true },
+  'London Overground': { 'colour': '#EE7623', 'solid': true },
+  'Liberty': { 'colour': '#61686B', 'solid': false },
+  'Lioness': { 'colour': '#FFA600', 'solid': false },
+  'Mildmay': { 'colour': '#006FE6', 'solid': false },
+  'Suffragette': { 'colour': '#18A95D', 'solid': false },
+  'Weaver': { 'colour': '#9B0058', 'solid': false },
+  'Windrush': { 'colour': '#DC241F', 'solid': false }
 };
 
 // Function to extract max-age from Cache-Control header
@@ -71,7 +72,7 @@ const extractLineStatuses = (data, showNames) => {
       allOtherLinesGood = false;
       disruptedLines.push({
         message: showNames ? line.name : '',
-        bgColor: lineColors[line.name] || '#000',
+        bgColor: lineColors[line.name].colour || '#000',
       });
     }
   });

--- a/site/tflStatus.js
+++ b/site/tflStatus.js
@@ -8,7 +8,7 @@
 // Define line colors
 // https://content.tfl.gov.uk/tfl-colour-standard-issue-08.pdf
 // plus new Overground line names: https://blog.tfl.gov.uk/2024/03/08/london-overground-lines/
-const lineColors = {
+const lineColours = {
   'Bakerloo': { 'colour': '#A65A2A', 'solid': true },
   'Central': { 'colour': '#E1251B', 'solid': true },
   'Circle': { 'colour': '#FFCD00', 'solid': true },
@@ -72,7 +72,7 @@ const extractLineStatuses = (data, showNames) => {
       allOtherLinesGood = false;
       disruptedLines.push({
         message: showNames ? line.name : '',
-        bgColor: lineColors[line.name].colour || '#000',
+        bgColor: lineColours[line.name].colour || '#000',
       });
     }
   });

--- a/site/tflStatus.test.js
+++ b/site/tflStatus.test.js
@@ -221,13 +221,13 @@ describe('extractLineStatuses', () => {
     it('should identify the disrupted line, with showNames=true', () => {
       const { allOtherLinesGood, disruptedLines } = extractLineStatuses(singleDisruptionResponse, true);
       expect(allOtherLinesGood).toBe(false);
-      expect(disruptedLines).toEqual([{ message: 'Waterloo & City', bgColor: '#6BCDB2' }]);
+      expect(disruptedLines).toEqual([{ message: 'Waterloo & City', bgColor: '#6BCDB2', solid: true }]);
     });
 
     it('should identify the disrupted line, with showNames=false', () => {
       const { allOtherLinesGood, disruptedLines } = extractLineStatuses(singleDisruptionResponse, false);
       expect(allOtherLinesGood).toBe(false);
-      expect(disruptedLines).toEqual([{ message: '', bgColor: '#6BCDB2' }]);
+      expect(disruptedLines).toEqual([{ message: '', bgColor: '#6BCDB2', solid: true }]);
     });
   });
 
@@ -236,10 +236,10 @@ describe('extractLineStatuses', () => {
       const { allOtherLinesGood, disruptedLines } = extractLineStatuses(multipleDisruptionsResponse, true);
       expect(allOtherLinesGood).toBe(false);
       expect(disruptedLines).toEqual([
-        { message: 'Central', bgColor: '#E1251B' },
-        { message: 'Metropolitan', bgColor: '#870F54' },
-        { message: 'Piccadilly', bgColor: '#000F9F' },
-        { message: 'Waterloo & City', bgColor: '#6BCDB2' },
+        { message: 'Central', bgColor: '#E1251B', solid: true },
+        { message: 'Metropolitan', bgColor: '#870F54', solid: true },
+        { message: 'Piccadilly', bgColor: '#000F9F', solid: true },
+        { message: 'Waterloo & City', bgColor: '#6BCDB2', solid: true },
       ]);
     });
 
@@ -247,10 +247,10 @@ describe('extractLineStatuses', () => {
       const { allOtherLinesGood, disruptedLines } = extractLineStatuses(multipleDisruptionsResponse, false);
       expect(allOtherLinesGood).toBe(false);
       expect(disruptedLines).toEqual([
-        { message: '', bgColor: '#E1251B' },
-        { message: '', bgColor: '#870F54' },
-        { message: '', bgColor: '#000F9F' },
-        { message: '', bgColor: '#6BCDB2' },
+        { message: '', bgColor: '#E1251B', solid: true },
+        { message: '', bgColor: '#870F54', solid: true },
+        { message: '', bgColor: '#000F9F', solid: true },
+        { message: '', bgColor: '#6BCDB2', solid: true },
       ]);
     });
   });
@@ -412,6 +412,7 @@ describe('fetchTfLStatus', () => {
       {
         message: 'Waterloo & City',
         bgColor: '#6BCDB2',
+        solid: true
       },
       {
         bgColor: "#004A9C",
@@ -432,18 +433,22 @@ describe('fetchTfLStatus', () => {
       {
         message: 'Central',
         bgColor: '#E1251B',
+        solid: true
       },
       {
         message: 'Metropolitan',
         bgColor: '#870F54',
+        solid: true
       },
       {
         message: 'Piccadilly',
         bgColor: '#000F9F',
+        solid: true
       },
       {
         message: 'Waterloo & City',
         bgColor: '#6BCDB2',
+        solid: true
       },
       {
         bgColor: "#004A9C",
@@ -479,6 +484,7 @@ describe('fetchTfLStatus', () => {
       {
         message: '',
         bgColor: '#6BCDB2',
+        solid: true
       }
     ]);
   });
@@ -495,18 +501,22 @@ describe('fetchTfLStatus', () => {
       {
         message: '',
         bgColor: '#E1251B',
+        solid: true
       },
       {
         message: '',
         bgColor: '#870F54',
+        solid: true
       },
       {
         message: '',
         bgColor: '#000F9F',
+        solid: true
       },
       {
         message: '',
         bgColor: '#6BCDB2',
+        solid: true
       }
     ]);
   });

--- a/site/tflStatus.test.js
+++ b/site/tflStatus.test.js
@@ -156,7 +156,7 @@ describe('renderStatusBlocks', () => {
   test('should render a single status block correctly and set --total-blocks', () => {
     const statuses = [{
       message: 'Good service on all lines',
-      bgColor: '#004A9C',
+      bgColour: '#004A9C',
     }];
 
     renderStatusBlocks(statuses);
@@ -172,10 +172,10 @@ describe('renderStatusBlocks', () => {
 
   test('should render multiple status blocks correctly and set --total-blocks', () => {
     const statuses = [
-      { message: 'Good service on all lines', bgColor: '#004A9C' },
-      { message: 'Central', bgColor: '#E1251B', striped: false },
-      { message: ' ', bgColor: '#FFFFFF', striped: false },
-      { message: 'Lioness', bgColor: '#FFA600', striped: true }
+      { message: 'Good service on all lines', bgColour: '#004A9C' },
+      { message: 'Central', bgColour: '#E1251B', striped: false },
+      { message: ' ', bgColour: '#FFFFFF', striped: false },
+      { message: 'Lioness', bgColour: '#FFA600', striped: true }
     ];
 
     renderStatusBlocks(statuses);
@@ -202,7 +202,7 @@ describe('renderStatusBlocks', () => {
     // should also have the striped class
     expect(blocks[3].textContent).toBe('Lioness');
     expect(blocks[3].style.backgroundColor).toBe('rgb(255, 166, 0)');
-    expect(blocks[3].classList.contains('striped')).toBe(true);
+    expect(blocks[3].querySelector('.stripe')).not.toBeNull(); // striped
 
     // Validate --total-blocks CSS property
     expect(window.getComputedStyle(document.documentElement).getPropertyValue('--total-blocks')).toBe("4");
@@ -231,13 +231,13 @@ describe('extractLineStatuses', () => {
     it('should identify the disrupted line, with showNames=true', () => {
       const { allOtherLinesGood, disruptedLines } = extractLineStatuses(singleDisruptionResponse, true);
       expect(allOtherLinesGood).toBe(false);
-      expect(disruptedLines).toEqual([{ message: 'Waterloo & City', bgColor: '#6BCDB2', striped: false }]);
+      expect(disruptedLines).toEqual([{ message: 'Waterloo & City', bgColour: '#6BCDB2', striped: false }]);
     });
 
     it('should identify the disrupted line, with showNames=false', () => {
       const { allOtherLinesGood, disruptedLines } = extractLineStatuses(singleDisruptionResponse, false);
       expect(allOtherLinesGood).toBe(false);
-      expect(disruptedLines).toEqual([{ message: '', bgColor: '#6BCDB2', striped: false }]);
+      expect(disruptedLines).toEqual([{ message: '', bgColour: '#6BCDB2', striped: false }]);
     });
   });
 
@@ -246,10 +246,10 @@ describe('extractLineStatuses', () => {
       const { allOtherLinesGood, disruptedLines } = extractLineStatuses(multipleDisruptionsResponse, true);
       expect(allOtherLinesGood).toBe(false);
       expect(disruptedLines).toEqual([
-        { message: 'Central', bgColor: '#E1251B', striped: false },
-        { message: 'Metropolitan', bgColor: '#870F54', striped: false },
-        { message: 'Piccadilly', bgColor: '#000F9F', striped: false },
-        { message: 'Waterloo & City', bgColor: '#6BCDB2', striped: false },
+        { message: 'Central', bgColour: '#E1251B', striped: false },
+        { message: 'Metropolitan', bgColour: '#870F54', striped: false },
+        { message: 'Piccadilly', bgColour: '#000F9F', striped: false },
+        { message: 'Waterloo & City', bgColour: '#6BCDB2', striped: false },
       ]);
     });
 
@@ -257,10 +257,10 @@ describe('extractLineStatuses', () => {
       const { allOtherLinesGood, disruptedLines } = extractLineStatuses(multipleDisruptionsResponse, false);
       expect(allOtherLinesGood).toBe(false);
       expect(disruptedLines).toEqual([
-        { message: '', bgColor: '#E1251B', striped: false },
-        { message: '', bgColor: '#870F54', striped: false },
-        { message: '', bgColor: '#000F9F', striped: false },
-        { message: '', bgColor: '#6BCDB2', striped: false },
+        { message: '', bgColour: '#E1251B', striped: false },
+        { message: '', bgColour: '#870F54', striped: false },
+        { message: '', bgColour: '#000F9F', striped: false },
+        { message: '', bgColour: '#6BCDB2', striped: false },
       ]);
     });
   });
@@ -348,14 +348,14 @@ describe('clearAndRender', () => {
   });
 
   it('should call renderFunction with given statuses', () => {
-    const mockStatuses = [{ message: 'test', bgColor: '#fff' }];
+    const mockStatuses = [{ message: 'test', bgColour: '#fff' }];
     clearAndRender(mockStatuses, mockRenderFunction);
     expect(mockRenderFunction).toHaveBeenCalledWith(mockStatuses);
   });
 
   it('should clear and render the statuses correctly', () => {
     document.body.innerHTML = '<div class="old-status"></div>';
-    const statuses = [{ message: 'New Status', bgColor: '#004A9C' }];
+    const statuses = [{ message: 'New Status', bgColour: '#004A9C' }];
 
     clearAndRender(statuses);
 
@@ -405,7 +405,7 @@ describe('fetchTfLStatus', () => {
     expect(result).toEqual([
       {
         message: 'Good service on all lines',
-        bgColor: '#004A9C',
+        bgColour: '#004A9C',
       },
     ]);
   });
@@ -421,11 +421,11 @@ describe('fetchTfLStatus', () => {
     expect(result).toEqual([
       {
         message: 'Waterloo & City',
-        bgColor: '#6BCDB2',
+        bgColour: '#6BCDB2',
         striped: false
       },
       {
-        bgColor: "#004A9C",
+        bgColour: "#004A9C",
         message: "Good service on all other lines",
       }
     ]);
@@ -442,26 +442,26 @@ describe('fetchTfLStatus', () => {
     expect(result).toEqual([
       {
         message: 'Central',
-        bgColor: '#E1251B',
+        bgColour: '#E1251B',
         striped: false
       },
       {
         message: 'Metropolitan',
-        bgColor: '#870F54',
+        bgColour: '#870F54',
         striped: false
       },
       {
         message: 'Piccadilly',
-        bgColor: '#000F9F',
+        bgColour: '#000F9F',
         striped: false
       },
       {
         message: 'Waterloo & City',
-        bgColor: '#6BCDB2',
+        bgColour: '#6BCDB2',
         striped: false
       },
       {
-        bgColor: "#004A9C",
+        bgColour: "#004A9C",
         message: "Good service on all other lines",
       }]);
   });
@@ -477,7 +477,7 @@ describe('fetchTfLStatus', () => {
     expect(result).toEqual([
       {
         message: 'Good service on all lines',
-        bgColor: '#004A9C',
+        bgColour: '#004A9C',
       },
     ]);
   });
@@ -493,7 +493,7 @@ describe('fetchTfLStatus', () => {
     expect(result).toEqual([
       {
         message: '',
-        bgColor: '#6BCDB2',
+        bgColour: '#6BCDB2',
         striped: false
       }
     ]);
@@ -510,22 +510,22 @@ describe('fetchTfLStatus', () => {
     expect(result).toEqual([
       {
         message: '',
-        bgColor: '#E1251B',
+        bgColour: '#E1251B',
         striped: false
       },
       {
         message: '',
-        bgColor: '#870F54',
+        bgColour: '#870F54',
         striped: false
       },
       {
         message: '',
-        bgColor: '#000F9F',
+        bgColour: '#000F9F',
         striped: false
       },
       {
         message: '',
-        bgColor: '#6BCDB2',
+        bgColour: '#6BCDB2',
         striped: false
       }
     ]);

--- a/site/tflStatus.test.js
+++ b/site/tflStatus.test.js
@@ -173,29 +173,39 @@ describe('renderStatusBlocks', () => {
   test('should render multiple status blocks correctly and set --total-blocks', () => {
     const statuses = [
       { message: 'Good service on all lines', bgColor: '#004A9C' },
-      { message: 'Central', bgColor: '#E1251B' },
-      { message: ' ', bgColor: '#FFFFFF' },
+      { message: 'Central', bgColor: '#E1251B', striped: false },
+      { message: ' ', bgColor: '#FFFFFF', striped: false },
+      { message: 'Lioness', bgColor: '#FFA600', striped: true }
     ];
 
     renderStatusBlocks(statuses);
 
     const blocks = document.querySelectorAll('.status-block');
-    expect(blocks.length).toBe(3);
+    expect(blocks.length).toBe(4);
 
     // Validate first block
     expect(blocks[0].textContent).toBe('Good service on all lines');
     expect(blocks[0].style.backgroundColor).toBe('rgb(0, 74, 156)');
+    expect(blocks[0].classList.contains('striped')).toBe(false);
 
     // Validate second block
     expect(blocks[1].textContent).toBe('Central');
     expect(blocks[1].style.backgroundColor).toBe('rgb(225, 37, 27)');
+    expect(blocks[1].classList.contains('striped')).toBe(false);
 
     // Validate third block
     expect(blocks[2].textContent).toBe(' ');
     expect(blocks[2].style.backgroundColor).toBe('rgb(255, 255, 255)');
+    expect(blocks[2].classList.contains('striped')).toBe(false);
+
+    // Validate fourth block
+    // should also have the striped class
+    expect(blocks[3].textContent).toBe('Lioness');
+    expect(blocks[3].style.backgroundColor).toBe('rgb(255, 166, 0)');
+    expect(blocks[3].classList.contains('striped')).toBe(true);
 
     // Validate --total-blocks CSS property
-    expect(window.getComputedStyle(document.documentElement).getPropertyValue('--total-blocks')).toBe("3");
+    expect(window.getComputedStyle(document.documentElement).getPropertyValue('--total-blocks')).toBe("4");
   });
 });
 
@@ -221,13 +231,13 @@ describe('extractLineStatuses', () => {
     it('should identify the disrupted line, with showNames=true', () => {
       const { allOtherLinesGood, disruptedLines } = extractLineStatuses(singleDisruptionResponse, true);
       expect(allOtherLinesGood).toBe(false);
-      expect(disruptedLines).toEqual([{ message: 'Waterloo & City', bgColor: '#6BCDB2', solid: true }]);
+      expect(disruptedLines).toEqual([{ message: 'Waterloo & City', bgColor: '#6BCDB2', striped: false }]);
     });
 
     it('should identify the disrupted line, with showNames=false', () => {
       const { allOtherLinesGood, disruptedLines } = extractLineStatuses(singleDisruptionResponse, false);
       expect(allOtherLinesGood).toBe(false);
-      expect(disruptedLines).toEqual([{ message: '', bgColor: '#6BCDB2', solid: true }]);
+      expect(disruptedLines).toEqual([{ message: '', bgColor: '#6BCDB2', striped: false }]);
     });
   });
 
@@ -236,10 +246,10 @@ describe('extractLineStatuses', () => {
       const { allOtherLinesGood, disruptedLines } = extractLineStatuses(multipleDisruptionsResponse, true);
       expect(allOtherLinesGood).toBe(false);
       expect(disruptedLines).toEqual([
-        { message: 'Central', bgColor: '#E1251B', solid: true },
-        { message: 'Metropolitan', bgColor: '#870F54', solid: true },
-        { message: 'Piccadilly', bgColor: '#000F9F', solid: true },
-        { message: 'Waterloo & City', bgColor: '#6BCDB2', solid: true },
+        { message: 'Central', bgColor: '#E1251B', striped: false },
+        { message: 'Metropolitan', bgColor: '#870F54', striped: false },
+        { message: 'Piccadilly', bgColor: '#000F9F', striped: false },
+        { message: 'Waterloo & City', bgColor: '#6BCDB2', striped: false },
       ]);
     });
 
@@ -247,10 +257,10 @@ describe('extractLineStatuses', () => {
       const { allOtherLinesGood, disruptedLines } = extractLineStatuses(multipleDisruptionsResponse, false);
       expect(allOtherLinesGood).toBe(false);
       expect(disruptedLines).toEqual([
-        { message: '', bgColor: '#E1251B', solid: true },
-        { message: '', bgColor: '#870F54', solid: true },
-        { message: '', bgColor: '#000F9F', solid: true },
-        { message: '', bgColor: '#6BCDB2', solid: true },
+        { message: '', bgColor: '#E1251B', striped: false },
+        { message: '', bgColor: '#870F54', striped: false },
+        { message: '', bgColor: '#000F9F', striped: false },
+        { message: '', bgColor: '#6BCDB2', striped: false },
       ]);
     });
   });
@@ -412,7 +422,7 @@ describe('fetchTfLStatus', () => {
       {
         message: 'Waterloo & City',
         bgColor: '#6BCDB2',
-        solid: true
+        striped: false
       },
       {
         bgColor: "#004A9C",
@@ -433,22 +443,22 @@ describe('fetchTfLStatus', () => {
       {
         message: 'Central',
         bgColor: '#E1251B',
-        solid: true
+        striped: false
       },
       {
         message: 'Metropolitan',
         bgColor: '#870F54',
-        solid: true
+        striped: false
       },
       {
         message: 'Piccadilly',
         bgColor: '#000F9F',
-        solid: true
+        striped: false
       },
       {
         message: 'Waterloo & City',
         bgColor: '#6BCDB2',
-        solid: true
+        striped: false
       },
       {
         bgColor: "#004A9C",
@@ -484,7 +494,7 @@ describe('fetchTfLStatus', () => {
       {
         message: '',
         bgColor: '#6BCDB2',
-        solid: true
+        striped: false
       }
     ]);
   });
@@ -501,22 +511,22 @@ describe('fetchTfLStatus', () => {
       {
         message: '',
         bgColor: '#E1251B',
-        solid: true
+        striped: false
       },
       {
         message: '',
         bgColor: '#870F54',
-        solid: true
+        striped: false
       },
       {
         message: '',
         bgColor: '#000F9F',
-        solid: true
+        striped: false
       },
       {
         message: '',
         bgColor: '#6BCDB2',
-        solid: true
+        striped: false
       }
     ]);
   });
@@ -532,7 +542,7 @@ describe('printUsageInstructions', () => {
 
   beforeAll(() => {
     // Mock console.log
-    consoleLogMock = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleLogMock = jest.spyOn(console, 'log').mockImplementation(() => { });
   });
 
   afterAll(() => {


### PR DESCRIPTION
adds support for the new [London Overground line names](https://madeby.tfl.gov.uk/2024/02/15/overground_line_names/?intcmp=75213) using [colours and layouts](https://blog.tfl.gov.uk/2024/03/08/london-overground-lines/) provided by TfL's Digital Standards team.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces support for the newly named London Overground lines, including their distinct colors and striped designs. It updates the status display system to render these new line styles correctly, modifying both the core functionality and the associated tests. The changes enhance the visual representation of line statuses, particularly for the new Overground lines, while maintaining compatibility with existing lines.

- **New Features**:
    - Added support for new London Overground line names with distinct colors and striped designs.
    - Implemented a new visual style for status blocks, including striped backgrounds for certain lines.
- **Enhancements**:
    - Updated the lineColours object to include information about whether a line should be displayed with stripes.
    - Modified the renderStatusBlocks function to create more complex DOM structures for status blocks, including separate text and stripe elements.
- **Tests**:
    - Updated existing tests to accommodate the new striped design and color representation changes.
    - Added a new test case to verify the rendering of striped status blocks.

<!-- Generated by sourcery-ai[bot]: end summary -->